### PR TITLE
fix: make excluded-urls.yaml writable

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -66,7 +66,7 @@ env:
   - name: URLS_FILE
     value: "/app/data/urls.yaml" # 🔧 Use writable data directory
   - name: EXCLUDED_URLS_FILE
-    value: "/app/config/excluded-urls.yaml" # ✅ Variable explicite
+    value: "/app/data/excluded-urls.yaml" # Writable copy in data volume
   # Autoswagger integration (values from autoswagger section below)
   - name: ENABLE_AUTOSWAGGER
     value: "false"
@@ -136,7 +136,26 @@ securityContext:
 # Node selector
 nodeSelector: {}
 # Init containers
-initContainers: []
+initContainers:
+  - name: copy-excluded-urls
+    image: busybox:latest
+    command:
+      - sh
+      - -c
+      - |
+        if [ ! -f /app/data/excluded-urls.yaml ]; then
+          echo "Copying excluded-urls.yaml to writable volume..."
+          cp /app/config/excluded-urls.yaml /app/data/excluded-urls.yaml
+          echo "Done!"
+        else
+          echo "excluded-urls.yaml already exists in data volume, skipping copy"
+        fi
+    volumeMounts:
+      - name: config-volume
+        mountPath: /app/config
+        readOnly: true
+      - name: data-volume
+        mountPath: /app/data
 # 🎯 Excluded URLs for the application - SOLUTION 1: Format liste YAML
 excludedUrls:
   - "monitoring.*"

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ h11==0.16.0
 h2==4.3.0
 hpack==4.1.0
 Hypercorn==0.17.3
-hyperframe==6.0.1
+hyperframe==6.1.0
 icecream==2.1.4
 idna==3.10
 iniconfig==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ frozenlist==1.5.0
 google-auth==2.37.0
 h11==0.16.0
 h2==4.3.0
-hpack==4.0.0
+hpack==4.1.0
 Hypercorn==0.17.3
 hyperframe==6.0.1
 icecream==2.1.4


### PR DESCRIPTION
## Problem
The `excluded-urls.yaml` file was mounted read-only from ConfigMap, causing errors when trying to exclude URLs via the web interface:
```
Erreur: [Errno 30] Read-only file system: '/app/config/excluded-urls.yaml'
```

## Solution
1. **Added initContainer** to copy `excluded-urls.yaml` from ConfigMap to `/app/data` (writable EmptyDir volume) on first pod start
2. **Changed EXCLUDED_URLS_FILE** env var to point to `/app/data/excluded-urls.yaml`
3. File persists in memory for pod lifetime and can be modified by the application

## Benefits
- The exclude URL feature (`×` button in Details column) now works properly
- Users can dynamically exclude URLs without redeploying
- Changes persist for the pod lifetime (until pod restart)
- On pod restart, original ConfigMap values are restored

## Note
This uses an EmptyDir volume, so exclusions are **not persistent across pod restarts**. For persistent exclusions, users should update the ConfigMap or use a PVC.