### PR TITLE
perf: faster non-blocking refresh + auto-exclude portal-checker

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -54,15 +54,30 @@ env:
 - name: PORT
   value: "5000"
 - name: MAX_CONCURRENT_REQUESTS
-  value: "3"
+  value: "20" # 🚀 plus de parallélisme = refresh plus rapide
 - name: REQUEST_TIMEOUT
   value: "5"
 - name: CACHE_TTL_SECONDS
   value: "900"
 - name: KUBERNETES_POLL_INTERVAL
   value: "600" # 🔍 10 minutes pour la découverte K8s normale
+- name: DISCOVERY_INTERVAL
+  value: "600" # ⏱️ re-découverte K8s par la tâche de fond
 - name: CHECK_INTERVAL
   value: "300" # 🔄 Fréquence de test des URLs en secondes
+- name: SSL_CACHE_TTL_SECONDS
+  value: "3600" # 🔐 cache des infos SSL (les certs changent rarement)
+# Auto-exclude portal-checker from its own URL list (downward API below)
+- name: EXCLUDE_SELF
+  value: "true"
+- name: POD_NAME
+  valueFrom:
+    fieldRef:
+      fieldPath: metadata.name
+- name: POD_NAMESPACE
+  valueFrom:
+    fieldRef:
+      fieldPath: metadata.namespace
 - name: URLS_FILE
   value: "/app/data/urls.yaml" # 🔧 Use writable data directory
 - name: EXCLUDED_URLS_FILE

--- a/src/api.py
+++ b/src/api.py
@@ -4,6 +4,7 @@ Flask API routes for Portal Checker
 
 import asyncio
 import os
+import threading
 from datetime import datetime
 from typing import Any, Dict, List
 
@@ -41,6 +42,55 @@ _test_results_cache: Dict[str, Any] = {"results": [], "last_updated": None}
 
 # Cache for swagger results
 _swagger_cache: Dict[str, Any] = {"results": [], "last_updated": None}
+
+# State for the asynchronous /refresh endpoint so that the UI can poll it
+# without blocking on a synchronous Kubernetes discovery + URL test pass.
+_refresh_state: Dict[str, Any] = {
+    "running": False,
+    "started_at": None,
+    "finished_at": None,
+    "last_error": None,
+}
+_refresh_lock = threading.Lock()
+
+
+def _run_full_refresh_sync() -> None:
+    """Re-discover URLs from Kubernetes and run a full URL test pass.
+
+    Runs in a worker thread spawned by the API endpoints so the HTTP request
+    can return immediately. State is exposed via /api/refresh-status.
+    """
+    global _refresh_state
+    try:
+        urls_data = get_all_urls_with_details(force_refresh=True)
+        save_urls_to_file(urls_data, URLS_FILE)
+        asyncio.run(_run_url_tests(update_cache=True))
+        logger.info(f"✅ Refresh asynchrone terminé: {len(urls_data)} URLs")
+        _refresh_state["last_error"] = None
+    except Exception as exc:
+        logger.error(f"❌ Erreur lors du refresh asynchrone: {exc}")
+        _refresh_state["last_error"] = str(exc)
+    finally:
+        _refresh_state["running"] = False
+        _refresh_state["finished_at"] = datetime.now()
+
+
+def _trigger_async_refresh() -> bool:
+    """Start a refresh in a background thread if one isn't already running.
+
+    Returns True if a new refresh was kicked off, False if one was already
+    in progress (the caller is told to wait/poll instead of stacking calls).
+    """
+    with _refresh_lock:
+        if _refresh_state["running"]:
+            return False
+        _refresh_state["running"] = True
+        _refresh_state["started_at"] = datetime.now()
+        _refresh_state["finished_at"] = None
+
+    thread = threading.Thread(target=_run_full_refresh_sync, daemon=True)
+    thread.start()
+    return True
 
 
 def _is_url_excluded_wrapper(url: str) -> bool:
@@ -224,38 +274,64 @@ def scan_swagger_url(url: str):
 
 @app.route("/refresh")
 def refresh():
-    """Force refresh of URL discovery and checks"""
+    """Trigger a non-blocking refresh and redirect back to the home page.
+
+    The actual Kubernetes discovery + URL test pass runs in a worker thread,
+    so the user is redirected immediately and sees the previous (cached)
+    results while the new ones are being computed.
+    """
     from flask import redirect
 
-    try:
-        # Discover URLs from Kubernetes (force refresh to bypass cache)
-        urls_data = get_all_urls_with_details(force_refresh=True)
-        save_urls_to_file(urls_data, URLS_FILE)
-
-        # Run tests
-        asyncio.run(_run_url_tests())
-
-        logger.info(f"✅ Refresh terminé: {len(urls_data)} URLs")
-
-        # Redirect to home page
-        return redirect("/")
-
-    except Exception as e:
-        logger.error(f"❌ Erreur lors du refresh: {e}")
-        return jsonify({"error": str(e), "status": "error"}), 500
+    started = _trigger_async_refresh()
+    if started:
+        logger.info("🔄 Refresh asynchrone déclenché via /refresh")
+    else:
+        logger.info("🔄 Refresh déjà en cours, redirection sans relance")
+    return redirect("/")
 
 
 @app.route("/api/refresh-async", methods=["POST"])
 def refresh_async():
-    """Trigger async refresh in background and return immediately"""
-    # Simply return - the background task will handle periodic refreshes
-    # Or the user can click the main Refresh button
-    logger.info("🔄 Refresh asynchrone demandé - utilisez le bouton Refresh principal")
+    """Trigger a refresh in the background and return immediately.
 
+    Returns 202 Accepted with the current refresh state so that the UI can
+    poll /api/refresh-status to know when fresh data is available.
+    """
+    started = _trigger_async_refresh()
+    return (
+        jsonify(
+            {
+                "status": "ok",
+                "started": started,
+                "message": "Refresh démarré"
+                if started
+                else "Refresh déjà en cours",
+                "running": _refresh_state["running"],
+                "started_at": _refresh_state["started_at"].isoformat()
+                if _refresh_state["started_at"]
+                else None,
+            }
+        ),
+        202,
+    )
+
+
+@app.route("/api/refresh-status")
+def refresh_status():
+    """Expose the current state of the background refresh task."""
     return jsonify(
         {
-            "message": "Utilisez le bouton Refresh pour mettre à jour les données",
-            "status": "ok",
+            "running": _refresh_state["running"],
+            "started_at": _refresh_state["started_at"].isoformat()
+            if _refresh_state["started_at"]
+            else None,
+            "finished_at": _refresh_state["finished_at"].isoformat()
+            if _refresh_state["finished_at"]
+            else None,
+            "last_error": _refresh_state["last_error"],
+            "last_results_updated": _test_results_cache["last_updated"].isoformat()
+            if _test_results_cache["last_updated"]
+            else None,
         }
     )
 

--- a/src/config.py
+++ b/src/config.py
@@ -14,8 +14,8 @@ LOG_FORMAT = os.getenv("LOG_FORMAT", "text")
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
 
 # Request Configuration
-REQUEST_TIMEOUT = int(os.getenv("REQUEST_TIMEOUT", "10"))
-MAX_CONCURRENT_REQUESTS = int(os.getenv("MAX_CONCURRENT_REQUESTS", "10"))
+REQUEST_TIMEOUT = int(os.getenv("REQUEST_TIMEOUT", "5"))
+MAX_CONCURRENT_REQUESTS = int(os.getenv("MAX_CONCURRENT_REQUESTS", "20"))
 
 # Cache Configuration
 CACHE_TTL_SECONDS = int(os.getenv("CACHE_TTL_SECONDS", "300"))  # 5 minutes
@@ -23,6 +23,11 @@ KUBERNETES_POLL_INTERVAL = int(
     os.getenv("KUBERNETES_POLL_INTERVAL", "600")
 )  # 10 minutes
 CHECK_INTERVAL = int(os.getenv("CHECK_INTERVAL", "30"))  # 30 seconds
+# How often the background task should re-discover URLs from Kubernetes.
+# Independent from KUBERNETES_POLL_INTERVAL (which is the K8s API call cache TTL).
+DISCOVERY_INTERVAL = int(os.getenv("DISCOVERY_INTERVAL", str(KUBERNETES_POLL_INTERVAL)))
+# SSL certificate info cache TTL (certs don't change frequently).
+SSL_CACHE_TTL_SECONDS = int(os.getenv("SSL_CACHE_TTL_SECONDS", "3600"))  # 1 hour
 
 # Swagger Discovery Configuration
 SWAGGER_DISCOVERY_INTERVAL = int(
@@ -46,6 +51,13 @@ CUSTOM_CERT: Optional[str] = os.getenv("CUSTOM_CERT")
 
 # Kubernetes Configuration
 KUBE_ENV = os.getenv("KUBE_ENV", "production")
+
+# Self-identification (used to auto-exclude portal-checker from its own URL list).
+# Populated via Kubernetes downward API in the deployment manifest.
+SELF_POD_NAME: Optional[str] = os.getenv("POD_NAME")
+SELF_POD_NAMESPACE: Optional[str] = os.getenv("POD_NAMESPACE")
+SELF_APP_NAME = os.getenv("SELF_APP_NAME", "portal-checker")
+EXCLUDE_SELF = os.getenv("EXCLUDE_SELF", "true").lower() == "true"
 
 # Features
 AUTO_REFRESH_ON_START = os.getenv("AUTO_REFRESH_ON_START", "true").lower() == "true"

--- a/src/kubernetes_client.py
+++ b/src/kubernetes_client.py
@@ -10,7 +10,15 @@ import yaml
 from kubernetes import client, config
 from loguru import logger
 
-from .config import EXCLUDED_URLS_FILE, KUBE_ENV, KUBERNETES_POLL_INTERVAL
+from .config import (
+    EXCLUDE_SELF,
+    EXCLUDED_URLS_FILE,
+    KUBE_ENV,
+    KUBERNETES_POLL_INTERVAL,
+    SELF_APP_NAME,
+    SELF_POD_NAME,
+    SELF_POD_NAMESPACE,
+)
 
 # Cache global pour les ressources Kubernetes
 _kubernetes_cache: Dict[str, Any] = {"data": None, "last_updated": None, "expiry": None}
@@ -147,6 +155,31 @@ def _filter_annotations(annotations: Dict[str, str]) -> Dict[str, str]:
     return result
 
 
+def _is_self_resource(name: str, namespace: str, labels: Dict[str, str]) -> bool:
+    """Detect whether the given Ingress/HTTPRoute belongs to the portal-checker
+    deployment itself, so that it can be excluded from the URL list by default.
+
+    Detection order:
+      1. Match against POD_NAME/POD_NAMESPACE injected via the K8s downward API
+         (the resource name typically equals the Helm release fullname, which is
+         a prefix of the pod name).
+      2. Fallback to a substring match on SELF_APP_NAME ("portal-checker").
+    """
+    if not EXCLUDE_SELF:
+        return False
+
+    if SELF_POD_NAMESPACE and namespace == SELF_POD_NAMESPACE:
+        if SELF_POD_NAME and SELF_POD_NAME.startswith(name):
+            return True
+        if (
+            labels.get("app.kubernetes.io/name") == SELF_APP_NAME
+            or labels.get("app.kubernetes.io/part-of") == SELF_APP_NAME
+        ):
+            return True
+
+    return SELF_APP_NAME in name
+
+
 def _deduplicate_urls(urls_data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Remove duplicate URLs based on (url, namespace, name) triplet"""
     seen: Set[Tuple[str, str, str]] = set()
@@ -198,10 +231,22 @@ def get_all_urls_with_details(force_refresh: bool = False) -> List[Dict[str, Any
         return []
 
     # Process Ingresses
+    self_excluded_count = 0
     for namespace in namespace_names:
         try:
             ingresses = v1.list_namespaced_ingress(namespace)
             for ingress in ingresses.items:
+                if _is_self_resource(
+                    ingress.metadata.name,
+                    namespace,
+                    ingress.metadata.labels or {},
+                ):
+                    self_excluded_count += 1
+                    logger.debug(
+                        f"🚫 Auto-exclusion de l'Ingress portal-checker: "
+                        f"{namespace}/{ingress.metadata.name}"
+                    )
+                    continue
                 ingress_class = None
                 if ingress.spec.ingress_class_name:
                     ingress_class = ingress.spec.ingress_class_name
@@ -260,6 +305,17 @@ def get_all_urls_with_details(force_refresh: bool = False) -> List[Dict[str, Any
 
             for route in routes.get("items", []):
                 route_name = route["metadata"]["name"]
+                if _is_self_resource(
+                    route_name,
+                    namespace,
+                    route["metadata"].get("labels", {}),
+                ):
+                    self_excluded_count += 1
+                    logger.debug(
+                        f"🚫 Auto-exclusion de l'HTTPRoute portal-checker: "
+                        f"{namespace}/{route_name}"
+                    )
+                    continue
                 for hostname in route["spec"].get("hostnames", []):
                     for rule in route["spec"].get("rules", []):
                         for match in rule.get("matches", [{}]):
@@ -313,6 +369,11 @@ def get_all_urls_with_details(force_refresh: bool = False) -> List[Dict[str, Any
             logger.debug(f"🚫 URL exclue: {data['url']}")
         else:
             filtered_urls.append(data)
+
+    if self_excluded_count:
+        logger.info(
+            f"🚫 {self_excluded_count} ressource(s) portal-checker auto-exclue(s)"
+        )
 
     logger.info(
         f"🔍 {len(all_urls_data)} URLs totales générées, {excluded_count} URLs exclues"

--- a/src/main.py
+++ b/src/main.py
@@ -11,8 +11,20 @@ from hypercorn import Config as HypercornConfig
 from loguru import logger
 
 from .api import _run_url_tests, app, refresh_urls_if_needed
-from .config import CHECK_INTERVAL, FLASK_ENV, LOG_FORMAT, LOG_LEVEL, PORT
-from .kubernetes_client import init_kubernetes
+from .config import (
+    CHECK_INTERVAL,
+    DISCOVERY_INTERVAL,
+    FLASK_ENV,
+    LOG_FORMAT,
+    LOG_LEVEL,
+    PORT,
+    URLS_FILE,
+)
+from .kubernetes_client import (
+    get_all_urls_with_details,
+    init_kubernetes,
+    save_urls_to_file,
+)
 
 
 def setup_logger(log_format: str = "text", log_level: str = "INFO") -> None:
@@ -72,16 +84,30 @@ def setup_logger(log_format: str = "text", log_level: str = "INFO") -> None:
 
 
 async def periodic_url_tests():
-    """Background task to periodically test URLs"""
+    """Background task to periodically re-discover and test URLs.
+
+    Re-runs the Kubernetes discovery on its own cadence (DISCOVERY_INTERVAL)
+    so newly-created Ingresses/HTTPRoutes are picked up automatically without
+    requiring a manual /refresh.
+    """
     global _stop_background_task
+    last_discovery_at = 0.0
 
     while not _stop_background_task:
         try:
+            now = asyncio.get_event_loop().time()
+            if now - last_discovery_at >= DISCOVERY_INTERVAL:
+                logger.debug("🔄 Re-découverte Kubernetes périodique")
+                try:
+                    urls_data = get_all_urls_with_details(force_refresh=True)
+                    save_urls_to_file(urls_data, URLS_FILE)
+                except Exception as exc:
+                    logger.error(f"❌ Erreur de re-découverte K8s: {exc}")
+                last_discovery_at = now
+
             logger.debug(
                 f"🔄 Démarrage du test périodique (intervalle: {CHECK_INTERVAL}s)"
             )
-
-            # Run tests with cache update
             await _run_url_tests(update_cache=True)
 
             if not _stop_background_task:

--- a/src/utils.py
+++ b/src/utils.py
@@ -23,6 +23,7 @@ from .config import (
     MAX_CONCURRENT_REQUESTS,
     REQUEST_TIMEOUT,
     SLACK_WEBHOOK_URL,
+    SSL_CACHE_TTL_SECONDS,
 )
 
 # Disable SSL warnings for development environment
@@ -64,8 +65,29 @@ def get_ssl_context() -> ssl.SSLContext:
     return ssl_context
 
 
+# SSL cert info cache: {(host, port): (timestamp, info)}.
+# Certs change rarely (typically every 60-90 days), so we don't need to
+# re-establish a TLS connection on every URL test cycle.
+_ssl_info_cache: Dict[tuple, tuple] = {}
+
+
+def _ssl_cache_get(key: tuple) -> Optional[Dict[str, Any]]:
+    entry = _ssl_info_cache.get(key)
+    if entry is None:
+        return None
+    cached_at, info = entry
+    if time.time() - cached_at > SSL_CACHE_TTL_SECONDS:
+        _ssl_info_cache.pop(key, None)
+        return None
+    return info
+
+
+def _ssl_cache_set(key: tuple, info: Optional[Dict[str, Any]]) -> None:
+    _ssl_info_cache[key] = (time.time(), info)
+
+
 async def get_ssl_cert_info(url: str) -> Optional[Dict[str, Any]]:
-    """Get SSL certificate information for a URL"""
+    """Get SSL certificate information for a URL (cached)."""
     try:
         parsed = urlparse(url if url.startswith("http") else f"https://{url}")
         hostname = parsed.hostname
@@ -73,6 +95,11 @@ async def get_ssl_cert_info(url: str) -> Optional[Dict[str, Any]]:
 
         if not hostname or parsed.scheme != "https":
             return None
+
+        cache_key = (hostname, port)
+        cached = _ssl_cache_get(cache_key)
+        if cached is not None:
+            return cached
 
         # Create SSL context for certificate retrieval
         # IMPORTANT: We need to verify SSL to get certificate info, even in dev mode
@@ -95,6 +122,7 @@ async def get_ssl_cert_info(url: str) -> Optional[Dict[str, Any]]:
         if not ssl_object:
             writer.close()
             await writer.wait_closed()
+            _ssl_cache_set(cache_key, None)
             return None
 
         # Get certificate
@@ -103,23 +131,27 @@ async def get_ssl_cert_info(url: str) -> Optional[Dict[str, Any]]:
         await writer.wait_closed()
 
         if not cert:
+            _ssl_cache_set(cache_key, None)
             return None
 
         # Parse expiration date
         not_after = cert.get("notAfter")
         if not not_after:
+            _ssl_cache_set(cache_key, None)
             return None
 
         # Parse date format: 'Jan 1 00:00:00 2025 GMT'
         expiry_date = datetime.strptime(not_after, "%b %d %H:%M:%S %Y %Z")
         days_remaining = (expiry_date - datetime.now()).days
 
-        return {
+        info = {
             "expiry_date": expiry_date.isoformat(),
             "days_remaining": days_remaining,
             "issuer": cert.get("issuer", []),
             "subject": cert.get("subject", []),
         }
+        _ssl_cache_set(cache_key, info)
+        return info
 
     except asyncio.TimeoutError:
         logger.debug(f"Timeout lors de la récupération du certificat SSL pour {url}")
@@ -229,6 +261,12 @@ async def check_single_url(
 
     start_time = time.time()
 
+    # Kick off the SSL cert fetch concurrently with the HTTP request so the
+    # extra TLS round trip doesn't add latency on top of the HTTP request.
+    ssl_task: Optional[asyncio.Task] = None
+    if full_url.startswith("https://"):
+        ssl_task = asyncio.create_task(get_ssl_cert_info(full_url))
+
     try:
         async with session.get(full_url, allow_redirects=True) as response:
             response_time = int((time.time() - start_time) * 1000)  # ms
@@ -262,16 +300,15 @@ async def check_single_url(
             elif status_code in [301, 302]:
                 details = "Redirection"
 
-            # Get SSL certificate info for HTTPS URLs
-            ssl_info = None
-            if full_url.startswith("https://"):
-                ssl_info = await get_ssl_cert_info(full_url)
-                if ssl_info:
-                    logger.debug(
-                        f"✅ SSL info récupérée pour {url}: {ssl_info.get('days_remaining')} jours restants"
-                    )
-                else:
-                    logger.debug(f"⚠️ Pas d'info SSL pour {url}")
+            # Collect SSL certificate info from the parallel task started
+            # before the HTTP request.
+            ssl_info: Optional[Dict[str, Any]] = None
+            if ssl_task is not None:
+                try:
+                    ssl_info = await ssl_task
+                except Exception as exc:
+                    logger.debug(f"⚠️ SSL fetch a échoué pour {url}: {exc}")
+                    ssl_info = None
             else:
                 # HTTP URL - mark explicitly as no SSL
                 ssl_info = {"http_only": True}
@@ -289,12 +326,16 @@ async def check_single_url(
             return data
 
     except asyncio.TimeoutError:
+        if ssl_task is not None:
+            ssl_task.cancel()
         data["status"] = 408
         data["details"] = "Timeout"
         data["response_time"] = int((time.time() - start_time) * 1000)
         return data
 
     except aiohttp.ClientError as e:
+        if ssl_task is not None:
+            ssl_task.cancel()
         error_msg = str(e)
         if "certificate" in error_msg.lower():
             data["status"] = 495
@@ -306,6 +347,8 @@ async def check_single_url(
         return data
 
     except Exception as e:
+        if ssl_task is not None:
+            ssl_task.cancel()
         data["status"] = 500
         data["details"] = f"Error: {str(e)[:150]}"
         data["response_time"] = int((time.time() - start_time) * 1000)

--- a/static/script.js
+++ b/static/script.js
@@ -261,47 +261,6 @@ function renderTable() {
     });
 }
 
-// Fonction pour formater les annotations - bouton compact avec nombre
-function formatAnnotations(annotations) {
-    if (!annotations) return '-';
-
-    try {
-        // Si c'est déjà une chaîne, essayez de l'analyser comme JSON
-        if (typeof annotations === 'string') {
-            try {
-                annotations = JSON.parse(annotations);
-            } catch (e) {
-                // Si ce n'est pas du JSON valide, retournez tel quel si non vide
-                return annotations.trim() ? annotations : '-';
-            }
-        }
-
-        // Vérifier si l'objet annotations a des propriétés
-        const annotationKeys = Object.keys(annotations || {});
-        if (annotationKeys.length === 0) {
-            return '-';
-        }
-
-        // Générer un ID unique pour ce bloc d'annotations
-        const dataId = 'data-' + Math.random().toString(36).substr(2, 9);
-
-        // Stocker les données d'annotations pour la modale
-        window.annotationsData = window.annotationsData || {};
-        window.annotationsData[dataId] = annotations;
-
-        // Créer un bouton compact avec le nombre
-        return `
-            <button class="annotations-btn" onclick="showAnnotationsModal('${dataId}')" title="${annotationKeys.length} annotation${annotationKeys.length > 1 ? 's' : ''}">
-                ${annotationKeys.length}
-            </button>
-        `;
-    } catch (error) {
-        // En cas d'erreur, retourner un tiret si vide ou le texte brut
-        const stringValue = String(annotations);
-        return stringValue.trim() ? stringValue : '-';
-    }
-}
-
 // Fonction pour afficher la modale avec les annotations
 function showAnnotationsModal(dataId) {
     const annotations = window.annotationsData[dataId];
@@ -468,6 +427,77 @@ function toggleSwaggerEndpoint(endpointId) {
 function closeSwaggerModal() {
     const modal = document.getElementById('swaggerModal');
     modal.style.display = 'none';
+}
+
+// Polling périodique des résultats sans recharger la page entière.
+// Remplace l'ancien <meta http-equiv="refresh"> qui forçait un full reload toutes les 2 min.
+const URL_POLL_INTERVAL_MS = 60_000;
+const REFRESH_STATUS_INTERVAL_MS = 2_000;
+let lastUpdatedISO = null;
+
+async function fetchUrlsAndRender() {
+    try {
+        const response = await fetch('/api/urls');
+        if (!response.ok) return;
+        const payload = await response.json();
+        if (!payload || !Array.isArray(payload.results)) return;
+
+        // Skip the re-render if the cache hasn't moved.
+        if (payload.last_updated && payload.last_updated === lastUpdatedISO) {
+            return;
+        }
+        lastUpdatedISO = payload.last_updated;
+
+        window.initialData = payload.results;
+        currentData = [...payload.results];
+        renderTable();
+    } catch (error) {
+        // Silent fail - keep showing the previous data
+    }
+}
+
+async function triggerRefresh() {
+    const btn = document.getElementById('refreshBtn');
+    if (btn) {
+        btn.disabled = true;
+        btn.dataset.originalText = btn.dataset.originalText || btn.textContent;
+        btn.textContent = 'Refreshing...';
+    }
+    try {
+        await fetch('/api/refresh-async', { method: 'POST' });
+        pollRefreshStatus();
+    } catch (error) {
+        if (btn) {
+            btn.disabled = false;
+            btn.textContent = btn.dataset.originalText || 'Refresh';
+        }
+    }
+}
+
+async function pollRefreshStatus() {
+    try {
+        const response = await fetch('/api/refresh-status');
+        if (!response.ok) return;
+        const status = await response.json();
+
+        if (status.running) {
+            setTimeout(pollRefreshStatus, REFRESH_STATUS_INTERVAL_MS);
+            return;
+        }
+
+        await fetchUrlsAndRender();
+        const btn = document.getElementById('refreshBtn');
+        if (btn) {
+            btn.disabled = false;
+            btn.textContent = btn.dataset.originalText || 'Refresh';
+        }
+    } catch (error) {
+        const btn = document.getElementById('refreshBtn');
+        if (btn) {
+            btn.disabled = false;
+            btn.textContent = btn.dataset.originalText || 'Refresh';
+        }
+    }
 }
 
 // Fonction pour charger les données Swagger
@@ -687,4 +717,11 @@ document.addEventListener('DOMContentLoaded', function() {
     // Rendu initial
     updateSortArrows();
     renderTable();
+
+    // Si la page a été ouverte avant que le cache n'ait été rempli, charger
+    // les résultats via /api/urls. Puis polling périodique pour rester à jour.
+    if (!Array.isArray(window.initialData) || window.initialData.length === 0) {
+        fetchUrlsAndRender();
+    }
+    setInterval(fetchUrlsAndRender, URL_POLL_INTERVAL_MS);
 });

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,7 +4,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="refresh" content="120">
     <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='favicon.ico') }}">
     <title>Portal Urls Checker</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
@@ -52,7 +51,7 @@
 
         <div class="search-bar">
             <input type="search" id="searchInput" placeholder="Rechercher...">
-            <button onclick="window.location.href='/refresh'">Refresh</button>
+            <button id="refreshBtn" onclick="triggerRefresh()">Refresh</button>
             <button onclick="showExcludedUrls()">Exclusions</button>
         </div>
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -44,12 +44,12 @@ class TestConfig:
             assert config.LOG_FORMAT == "text"
 
     def test_default_request_timeout(self):
-        """Test default request timeout is 10 seconds"""
+        """Test default request timeout is 5 seconds"""
         with patch.dict(os.environ, {}, clear=True):
             import importlib
             import src.config as config
             importlib.reload(config)
-            assert config.REQUEST_TIMEOUT == 10
+            assert config.REQUEST_TIMEOUT == 5
 
     def test_custom_request_timeout(self):
         """Test request timeout can be customized"""
@@ -60,12 +60,12 @@ class TestConfig:
             assert config.REQUEST_TIMEOUT == 30
 
     def test_default_max_concurrent_requests(self):
-        """Test default max concurrent requests is 10"""
+        """Test default max concurrent requests is 20"""
         with patch.dict(os.environ, {}, clear=True):
             import importlib
             import src.config as config
             importlib.reload(config)
-            assert config.MAX_CONCURRENT_REQUESTS == 10
+            assert config.MAX_CONCURRENT_REQUESTS == 20
 
     def test_default_cache_ttl(self):
         """Test default cache TTL is 300 seconds (5 minutes)"""

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -90,34 +90,23 @@ class TestFlaskRoutes:
         # Should return HTML
         assert b'<!DOCTYPE html>' in response.data or b'<html' in response.data
 
-    @patch('src.api.get_all_urls_with_details')
-    @patch('src.api.save_urls_to_file')
-    @patch('src.api.asyncio.run')
-    def test_refresh_endpoint_redirect(self, mock_run, mock_save, mock_get_urls, client):
-        """Test /refresh endpoint redirects to home"""
-        mock_get_urls.return_value = []
-        mock_run.return_value = None
+    @patch('src.api._trigger_async_refresh')
+    def test_refresh_endpoint_redirect(self, mock_trigger, client):
+        """Test /refresh endpoint redirects to home without blocking."""
+        mock_trigger.return_value = True
 
         response = client.get('/refresh', follow_redirects=False)
-        # Should redirect to home page
-        assert response.status_code in [302, 200]  # 302 redirect or 200 if followed
+        # Should redirect to home page (the work runs in a worker thread)
+        assert response.status_code in [302, 200]
+        mock_trigger.assert_called_once()
 
-    @patch('src.api.get_all_urls_with_details')
-    @patch('src.api.save_urls_to_file')
-    def test_refresh_endpoint_discovers_urls(self, mock_save, mock_get_urls, client):
-        """Test /refresh endpoint discovers URLs from Kubernetes"""
-        mock_get_urls.return_value = [
-            {
-                "url": "example.com",
-                "namespace": "default",
-                "name": "test-service",
-                "type": "Ingress"
-            }
-        ]
+    @patch('src.api._trigger_async_refresh')
+    def test_refresh_endpoint_triggers_async_refresh(self, mock_trigger, client):
+        """Test /refresh delegates to the non-blocking refresh trigger."""
+        mock_trigger.return_value = True
 
-        response = client.get('/refresh', follow_redirects=False)
-        # Should call discovery functions
-        mock_get_urls.assert_called_once()
+        client.get('/refresh', follow_redirects=False)
+        mock_trigger.assert_called_once()
 
     def test_exclude_url_endpoint(self, client):
         """Test /api/exclude endpoint adds URL to exclusion list"""
@@ -156,10 +145,25 @@ class TestFlaskRoutes:
         assert data['status'] == 'error'
         assert 'URL required' in data['error']
 
-    def test_refresh_async_endpoint(self, client):
-        """Test /api/refresh-async endpoint"""
+    @patch('src.api._trigger_async_refresh')
+    def test_refresh_async_endpoint(self, mock_trigger, client):
+        """Test /api/refresh-async endpoint kicks off a background refresh."""
+        mock_trigger.return_value = True
         response = client.post('/api/refresh-async')
+
+        assert response.status_code == 202
+        data = response.get_json()
+        assert data['status'] == 'ok'
+        assert data['started'] is True
+        mock_trigger.assert_called_once()
+
+    def test_refresh_status_endpoint(self, client):
+        """Test /api/refresh-status returns the current refresh state."""
+        response = client.get('/api/refresh-status')
 
         assert response.status_code == 200
         data = response.get_json()
-        assert data['status'] == 'ok'
+        assert 'running' in data
+        assert 'started_at' in data
+        assert 'finished_at' in data
+        assert 'last_error' in data

--- a/uv.lock
+++ b/uv.lock
@@ -765,7 +765,7 @@ wheels = [
 
 [[package]]
 name = "portal-checker"
-version = "3.0.9"
+version = "3.0.10"
 source = { editable = "." }
 dependencies = [
     { name = "aiohappyeyeballs" },


### PR DESCRIPTION
- /refresh and /api/refresh-async now run discovery + URL tests in a
  worker thread and return immediately; new /api/refresh-status lets the
  UI poll for completion instead of blocking the request.
- Background task now re-discovers Kubernetes resources on each tick
  (DISCOVERY_INTERVAL), so newly created Ingress/HTTPRoute resources
  appear without a manual refresh.
- Fetch SSL cert info concurrently with the HTTP request and cache it
  per (host, port) for SSL_CACHE_TTL_SECONDS (1h) so we no longer pay a
  second TLS handshake on every URL on every cycle.
- Auto-exclude the portal-checker deployment itself from the URL list
  using the K8s downward API (POD_NAME/POD_NAMESPACE) with a name-based
  fallback. Disable via EXCLUDE_SELF=false.
- Bump default MAX_CONCURRENT_REQUESTS 10->20 and lower default
  REQUEST_TIMEOUT 10->5 for snappier refreshes; helm values updated.
- Drop dead code: <meta http-equiv="refresh"> full-page reload, the
  no-op /api/refresh-async stub, the unused formatAnnotations() helper.
- Replace meta-refresh with a JS polling loop on /api/urls so the table
  updates in place without losing sort/search state.

https://claude.ai/code/session_01XzzSro9kwM9ujySexo6ody