### PR TITLE
feat(ci): publish Helm chart to OCI registries (GHCR + Docker Hub)

### DIFF
--- a/.github/workflows/full-release-on-main-merge.yml
+++ b/.github/workflows/full-release-on-main-merge.yml
@@ -208,22 +208,75 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v4
 
-      - name: Package and release Helm chart
+      - name: Package Helm chart
+        id: helm_package
         run: |
           # Mettre à jour la version du chart
           NEW_VERSION="${{ steps.bump_version.outputs.new_version }}"
           sed -i "s/^version: .*/version: $NEW_VERSION/" helm/Chart.yaml
           sed -i "s/^appVersion: .*/appVersion: $NEW_VERSION/" helm/Chart.yaml
-          
+
           # Packager le chart
           helm package helm/ --destination .
-          
+
+          echo "chart_file=portal-checker-${NEW_VERSION}.tgz" >> $GITHUB_OUTPUT
+
           # Créer ou mettre à jour l'index Helm si nécessaire
           if [ -f index.yaml ]; then
             helm repo index . --merge index.yaml
           else
             helm repo index .
           fi
+
+      - name: Authenticate Helm with GHCR (OCI)
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io \
+            -u ${{ github.actor }} --password-stdin
+
+      - name: Push Helm chart to GHCR (OCI)
+        run: |
+          helm push "${{ steps.helm_package.outputs.chart_file }}" \
+            oci://ghcr.io/${{ github.repository_owner }}/charts
+
+      - name: Authenticate Helm with Docker Hub (OCI)
+        run: |
+          echo "${{ secrets.DOCKER_PASSWORD }}" | helm registry login registry-1.docker.io \
+            -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+
+      - name: Push Helm chart to Docker Hub (OCI)
+        run: |
+          # Repo séparé de l'image pour éviter la confusion docker pull / helm pull
+          # Rename tgz to push to repo named portal-checker-chart
+          NEW_VERSION="${{ steps.bump_version.outputs.new_version }}"
+          cp "${{ steps.helm_package.outputs.chart_file }}" "portal-checker-chart-${NEW_VERSION}.tgz"
+          helm push "portal-checker-chart-${NEW_VERSION}.tgz" \
+            oci://registry-1.docker.io/${{ secrets.DOCKER_USERNAME }}
+
+      - name: Push artifacthub-repo.yml metadata to OCI registries
+        run: |
+          # Push artifacthub-repo.yml as OCI artifact for ownership verification on ArtifactHub
+          # See: https://artifacthub.io/docs/topics/repositories/helm-charts/#oci
+          if ! command -v oras >/dev/null 2>&1; then
+            curl -LO https://github.com/oras-project/oras/releases/download/v1.2.0/oras_1.2.0_linux_amd64.tar.gz
+            mkdir -p oras-install/
+            tar -zxf oras_1.2.0_linux_amd64.tar.gz -C oras-install/
+            sudo mv oras-install/oras /usr/local/bin/
+            rm -rf oras_1.2.0_linux_amd64.tar.gz oras-install/
+          fi
+
+          # GHCR
+          echo "${{ secrets.GITHUB_TOKEN }}" | oras login ghcr.io \
+            -u ${{ github.actor }} --password-stdin
+          oras push ghcr.io/${{ github.repository_owner }}/charts/portal-checker:artifacthub.io \
+            --config /dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
+            helm/artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml
+
+          # Docker Hub
+          echo "${{ secrets.DOCKER_PASSWORD }}" | oras login registry-1.docker.io \
+            -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+          oras push registry-1.docker.io/${{ secrets.DOCKER_USERNAME }}/portal-checker-chart:artifacthub.io \
+            --config /dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
+            helm/artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml
 
       - name: Summary
         run: |
@@ -234,8 +287,10 @@ jobs:
           echo "- 🐳 Docker image built and pushed" >> $GITHUB_STEP_SUMMARY
           echo "- 🏷️ Git tag created and pushed" >> $GITHUB_STEP_SUMMARY
           echo "- 📖 GitHub release created with changelog" >> $GITHUB_STEP_SUMMARY
-          echo "- ⚙️ Helm chart version updated" >> $GITHUB_STEP_SUMMARY
+          echo "- ⚙️ Helm chart version updated and pushed to OCI registries" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### 🔗 Links:" >> $GITHUB_STEP_SUMMARY
           echo "- [GitHub Release](https://github.com/${{ github.repository }}/releases/tag/${{ steps.bump_version.outputs.tag_name }})" >> $GITHUB_STEP_SUMMARY
-          echo "- [Docker Image](https://ghcr.io/${{ github.repository }}:${{ steps.bump_version.outputs.new_version }})" >> $GITHUB_STEP_SUMMARY
+          echo "- [Docker Image (Docker Hub)](https://hub.docker.com/r/${{ secrets.DOCKER_USERNAME }}/portal-checker)" >> $GITHUB_STEP_SUMMARY
+          echo "- Helm chart (GHCR): \`oci://ghcr.io/${{ github.repository_owner }}/charts/portal-checker:${{ steps.bump_version.outputs.new_version }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Helm chart (Docker Hub): \`oci://registry-1.docker.io/${{ secrets.DOCKER_USERNAME }}/portal-checker-chart:${{ steps.bump_version.outputs.new_version }}\`" >> $GITHUB_STEP_SUMMARY

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ __pycache__/
 .eggs/
 dist/
 build/
+.scannerwork/report-task.txt
+.scannerwork/.sonar_lock

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,11 +2,37 @@ apiVersion: "v2"
 name: "portal-checker"
 version: 1.4.1
 appVersion: "3.0.0"
-description: A Helm chart for portal checker
+description: A Helm chart for portal checker - Kubernetes Ingress/HTTPRoute portal monitoring with Swagger/OpenAPI discovery
 type: application
-
+home: https://github.com/didlawowo/portal-checker
+sources:
+  - https://github.com/didlawowo/portal-checker
+keywords:
+  - portal
+  - monitoring
+  - kubernetes
+  - ingress
+  - httproute
+  - swagger
+  - openapi
+  - api-discovery
 icon: https://avatars.githubusercontent.com/u/12622760?v=4
 
 maintainers:
 - name: didlawowo
   email: chris@dc-consulting.pro
+
+annotations:
+  artifacthub.io/license: MIT
+  artifacthub.io/category: monitoring-logging
+  artifacthub.io/containsSecurityUpdates: "false"
+  artifacthub.io/links: |
+    - name: GitHub
+      url: https://github.com/didlawowo/portal-checker
+    - name: Docker Image
+      url: https://hub.docker.com/r/fizzbuzz2/portal-checker
+    - name: Issues
+      url: https://github.com/didlawowo/portal-checker/issues
+  artifacthub.io/images: |
+    - name: portal-checker
+      image: docker.io/fizzbuzz2/portal-checker:3.0.0

--- a/helm/artifacthub-repo.yml
+++ b/helm/artifacthub-repo.yml
@@ -1,0 +1,4 @@
+repositoryID: ""
+owners:
+  - name: didlawowo
+    email: chris@dc-consulting.pro


### PR DESCRIPTION
## Summary
- Publie le chart Helm sur deux registres OCI à chaque release : **GHCR** (`oci://ghcr.io/didlawowo/charts/portal-checker`) et **Docker Hub** (`oci://registry-1.docker.io/fizzbuzz2/portal-checker-chart`)
- Enrichit `helm/Chart.yaml` avec les annotations ArtifactHub (license, links, images, keywords, sources, home)
- Ajoute `helm/artifacthub-repo.yml` pushé en OCI via `oras` pour la vérification d'ownership sur ArtifactHub

L'image Docker continue d'être publiée sur Docker Hub (déjà en place, non touché).

## Test plan
- [ ] Merge sur main → workflow `Full Release on Main Merge` se déclenche
- [ ] Vérifier que `helm pull oci://ghcr.io/didlawowo/charts/portal-checker --version <new-version>` fonctionne
- [ ] Vérifier que `helm pull oci://registry-1.docker.io/fizzbuzz2/portal-checker-chart --version <new-version>` fonctionne
- [ ] Aller sur https://artifacthub.io et enregistrer le repo OCI (`Add repository` → Helm charts → OCI URL)
- [ ] Vérifier que le badge "Verified Publisher" apparaît grâce à `artifacthub-repo.yml`

## Notes
- Le repo Docker Hub pour le chart est volontairement séparé de l'image (`portal-checker-chart` vs `portal-checker`) pour éviter la confusion `docker pull` vs `helm pull`
- Le repo GHCR `charts` doit être créé public manuellement la première fois (ou laissé en private si on veut)
- Pour ArtifactHub : après le premier push, récupérer le `repositoryID` depuis ArtifactHub et le réinjecter dans `helm/artifacthub-repo.yml` (actuellement vide) puis re-push

🤖 Generated with [Claude Code](https://claude.com/claude-code)