### PR TITLE
fix(ci): prevent Helm chart push from overwriting Docker image

### DIFF
--- a/.github/workflows/full-release-on-main-merge.yml
+++ b/.github/workflows/full-release-on-main-merge.yml
@@ -243,12 +243,18 @@ jobs:
           echo "${{ secrets.DOCKER_PASSWORD }}" | helm registry login registry-1.docker.io \
             -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
-      - name: Push Helm chart to Docker Hub (OCI)
+      - name: Package and push Helm chart to Docker Hub (OCI)
+        id: helm_package_dh
         run: |
-          # Repo séparé de l'image pour éviter la confusion docker pull / helm pull
-          # Rename tgz to push to repo named portal-checker-chart
+          # IMPORTANT: helm push uses the chart name from Chart.yaml, not the .tgz file name.
+          # Pushing chart "portal-checker" to oci://.../fizzbuzz2 would overwrite the Docker image
+          # at fizzbuzz2/portal-checker. We package a renamed copy "portal-checker-chart" so it
+          # lands at fizzbuzz2/portal-checker-chart, separate from the image repo.
           NEW_VERSION="${{ steps.bump_version.outputs.new_version }}"
-          cp "${{ steps.helm_package.outputs.chart_file }}" "portal-checker-chart-${NEW_VERSION}.tgz"
+          rm -rf /tmp/helm-dh
+          cp -r helm /tmp/helm-dh
+          sed -i 's/^name: .*/name: "portal-checker-chart"/' /tmp/helm-dh/Chart.yaml
+          helm package /tmp/helm-dh --destination .
           helm push "portal-checker-chart-${NEW_VERSION}.tgz" \
             oci://registry-1.docker.io/${{ secrets.DOCKER_USERNAME }}
 


### PR DESCRIPTION
## Bug

Le release workflow écrasait l'image Docker sur Docker Hub à chaque release.

`helm push` utilise le **nom du chart depuis `Chart.yaml`**, pas le nom du fichier `.tgz`. Le code précédent copiait le `.tgz` sous un nouveau nom mais le nom de chart embarqué restait `portal-checker`, donc le push allait à `fizzbuzz2/portal-checker` (la même URL que l'image Docker !) au lieu de `fizzbuzz2/portal-checker-chart`.

**Symptôme** : les pods qui utilisaient `fizzbuzz2/portal-checker:<version>` plantaient avec `failed to generate spec: no command specified` — le manifest OCI était un chart Helm, pas une image.

**Versions affectées sur Docker Hub** : `3.0.14`, `3.0.15`, `3.0.16` (toutes les releases après #58)

## Fix

Packager une copie de `helm/` dans `/tmp/helm-dh` avec `Chart.yaml` renommé en `portal-checker-chart`, puis `helm push` cette copie. L'artefact arrive bien à `fizzbuzz2/portal-checker-chart`, séparé de l'image.

GHCR n'est pas affecté (sous-chemin `/charts/` qui isole).

## Étapes manuelles après merge

1. **Rebuilder l'image** pour les versions corrompues (3.0.14-3.0.16). Le plus simple : push un commit vide ou trigger le `docker-build-on-branch-push.yml` manuellement sur main, puis re-tag manuellement sur Docker Hub.
   ```bash
   # Local quick fix pour 3.0.16
   docker buildx build --platform linux/amd64,linux/arm64 \
     -f docker/Dockerfile \
     -t fizzbuzz2/portal-checker:3.0.16 \
     -t fizzbuzz2/portal-checker:latest \
     --push .
   ```
2. Cette PR merge → la prochaine release (3.0.17) sera saine.

## Test plan
- [ ] Merge sur main
- [ ] Attendre release auto (3.0.17)
- [ ] Vérifier `docker pull fizzbuzz2/portal-checker:3.0.17` renvoie bien une image (et pas un chart)
- [ ] Vérifier `helm pull oci://registry-1.docker.io/fizzbuzz2/portal-checker-chart --version 3.0.17` fonctionne
- [ ] Vérifier `helm pull oci://ghcr.io/didlawowo/charts/portal-checker --version 3.0.17` fonctionne

🤖 Generated with [Claude Code](https://claude.com/claude-code)