### PR TITLE
fix(chart)!: strip personal data and local TLS key from published chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ excludedUrls:
   - "monitoring.*"           # Exclude all monitoring subdomains
   - "*.internal/*"           # Exclude internal paths
   - "grafana.*/api/health"   # Exclude specific health endpoints
-  - "*.dc-tech.work/api"     # Exclude API paths on specific domain
+  - "*.example.com/api"      # Exclude API paths on specific domain
 ```
 
 Or use Kubernetes annotations:

--- a/helm/.helmignore
+++ b/helm/.helmignore
@@ -1,0 +1,31 @@
+# Patterns to ignore when building Helm packages.
+# Default Helm patterns:
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+
+# Project-specific: exclude development-only values overrides
+values/
+
+# Never package local TLS material (real certs are mounted at runtime)
+certs/
+*.crt
+*.pem
+*.key

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -169,13 +169,15 @@ initContainers:
     readOnly: true
   - name: data-volume
     mountPath: /app/data
-# 🎯 Excluded URLs for the application - SOLUTION 1: Format liste YAML
-excludedUrls:
-- "monitoring.*"
-- "*.internal/*"
-- "infisical.dc-tech.work/ss-webhook"
-- "grafana.dc-tech.work/metrics"
-- "prometheus.dc-tech.work/*"
+# Excluded URLs for the application (fnmatch patterns)
+# Override these with your own list at install time.
+excludedUrls: []
+# Examples (uncomment / replace with your domains):
+# excludedUrls:
+#   - "monitoring.*"
+#   - "*.internal/*"
+#   - "grafana.example.com/metrics"
+#   - "prometheus.example.com/*"
 # Certificate configuration
 certificate:
   enabled: false


### PR DESCRIPTION
## 🚨 Security note

Le chart publié sur les registres OCI embarquait `helm/certs/key.pem` (clé privée TLS locale de dev). Ces fichiers étaient dans `.gitignore` mais **`.gitignore` n'affecte pas `helm package`** — il faut `.helmignore`.

**Versions chart affectées** : `3.0.14`, `3.0.15`, `3.0.16`, `3.0.17` sur :
- `oci://ghcr.io/didlawowo/charts/portal-checker`
- `oci://registry-1.docker.io/fizzbuzz2/portal-checker-chart`

## What was leaking

| Path | Type |
| ---- | ---- |
| `helm/certs/cert.crt` | TLS cert (local dev) |
| `helm/certs/key.pem` | **TLS private key (local dev)** |
| `helm/values/docker.yaml` | Dev branch overrides (git metadata, dev tag) |
| `helm/values/README.md` | Internal contributor doc |
| `helm/values.yaml` `excludedUrls` | Hardcoded personal domains (`*.dc-tech.work`) |
| `README.md` exclusions example | Reference to `*.dc-tech.work` |

## Changes
- Add `helm/.helmignore` excluding `values/`, `certs/`, `*.crt`, `*.pem`, `*.key`
- Set `excludedUrls: []` in `values.yaml` with commented generic examples
- Replace `dc-tech.work` example in README by `example.com`

Verified `helm package helm/` output:
```
portal-checker/Chart.yaml
portal-checker/values.yaml
portal-checker/templates/...
portal-checker/.helmignore
portal-checker/artifacthub-repo.yml
```
(plus de `certs/`, plus de `values/`)

## ⚠️ Required manual actions after merge
1. **Revoke** the leaked TLS key if it was ever used in any environment (looks like local dev material but worth a sanity check)
2. **Delete** the affected chart versions (3.0.14–3.0.17) from:
   - GHCR : https://github.com/didlawowo?tab=packages
   - Docker Hub : https://hub.docker.com/r/fizzbuzz2/portal-checker-chart/tags

## Test plan
- [ ] Merge → next release (3.0.18) published cleanly
- [ ] `helm pull oci://ghcr.io/didlawowo/charts/portal-checker --version 3.0.18 && tar -tzf portal-checker-3.0.18.tgz` → no `certs/`, no `values/`
- [ ] Manual revocation/deletion as listed above

🤖 Generated with [Claude Code](https://claude.com/claude-code)