### PR TITLE
feat: auto-refresh toggle toutes les minutes

### DIFF
--- a/.github/workflows/docker-build-on-branch-push.yml
+++ b/.github/workflows/docker-build-on-branch-push.yml
@@ -63,6 +63,7 @@ jobs:
             PR_NUMBER=${{ github.event.pull_request.number }}
             echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
             echo "pr_tag=pr-${PR_NUMBER}-${SHA}" >> $GITHUB_OUTPUT
+            echo "pr_tag_simple=pr-${PR_NUMBER}" >> $GITHUB_OUTPUT
           fi
 
       - name: Build Multi-Platform Docker Image (with optional push)
@@ -80,6 +81,7 @@ jobs:
           tags: |
             ${{ steps.check-secrets.outputs.available == 'true' && format('{0}/portal-checker:{1}', secrets.DOCKER_USERNAME, steps.extract-metadata.outputs.branch) || 'portal-checker:local' }}-${{ steps.extract-metadata.outputs.sha }}
             ${{ steps.check-secrets.outputs.available == 'true' && github.event_name == 'pull_request' && format('{0}/portal-checker:{1}', secrets.DOCKER_USERNAME, steps.extract-metadata.outputs.pr_tag) || '' }}
+            ${{ steps.check-secrets.outputs.available == 'true' && github.event_name == 'pull_request' && format('{0}/portal-checker:{1}', secrets.DOCKER_USERNAME, steps.extract-metadata.outputs.pr_tag_simple) || '' }}
           cache-from: type=gha
 
       - name: Generate Build Summary Report
@@ -93,6 +95,7 @@ jobs:
           echo "- 🐳 Docker Hub Repository: ${{ secrets.DOCKER_USERNAME }}/portal-checker" >> $GITHUB_STEP_SUMMARY
           echo "- 🏗️ Docker Tag: ${{ steps.extract-metadata.outputs.branch }}-${{ steps.extract-metadata.outputs.sha }}" >> $GITHUB_STEP_SUMMARY
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "- 🔖 PR Tag: ${{ steps.extract-metadata.outputs.pr_tag }}" >> $GITHUB_STEP_SUMMARY
+            echo "- 🔖 PR Tag (SHA): ${{ steps.extract-metadata.outputs.pr_tag }}" >> $GITHUB_STEP_SUMMARY
+            echo "- 🔖 PR Tag (ArgoCD): ${{ steps.extract-metadata.outputs.pr_tag_simple }}" >> $GITHUB_STEP_SUMMARY
             echo "- 🔗 Preview URL: https://pc-pr-${{ steps.extract-metadata.outputs.pr_number }}.dc-tech.work" >> $GITHUB_STEP_SUMMARY
           fi

--- a/.github/workflows/docker-build-on-branch-push.yml
+++ b/.github/workflows/docker-build-on-branch-push.yml
@@ -68,7 +68,6 @@ jobs:
             ${{ secrets.DOCKER_USERNAME }}/portal-checker:${{ steps.extract-metadata.outputs.branch }}-${{ steps.extract-metadata.outputs.sha }}
             ${{ github.event_name == 'pull_request' && format('{0}/portal-checker:{1}', secrets.DOCKER_USERNAME, steps.extract-metadata.outputs.pr_tag) || '' }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Generate Build Summary Report
         run: |

--- a/.github/workflows/docker-build-on-branch-push.yml
+++ b/.github/workflows/docker-build-on-branch-push.yml
@@ -27,7 +27,19 @@ jobs:
       - name: Setup Docker Buildx for Multi-Platform Builds
         uses: docker/setup-buildx-action@v4
 
+      - name: Check Docker Hub secrets availability
+        id: check-secrets
+        run: |
+          if [ -n "${{ secrets.DOCKER_USERNAME }}" ] && [ -n "${{ secrets.DOCKER_PASSWORD }}" ]; then
+            echo "available=true" >> $GITHUB_OUTPUT
+            echo "✅ Docker Hub secrets are available"
+          else
+            echo "available=false" >> $GITHUB_OUTPUT
+            echo "⚠️ Docker Hub secrets are missing — build will run without push"
+          fi
+
       - name: Authenticate with Docker Hub
+        if: steps.check-secrets.outputs.available == 'true'
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -53,20 +65,21 @@ jobs:
             echo "pr_tag=pr-${PR_NUMBER}-${SHA}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Build Multi-Platform Docker Image and Push to Docker Hub
+      - name: Build Multi-Platform Docker Image (with optional push)
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ./docker/Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ steps.check-secrets.outputs.available == 'true' }}
+          load: false
 
-          sbom: true
-          provenance: mode=max
+          sbom: ${{ steps.check-secrets.outputs.available == 'true' }}
+          provenance: ${{ steps.check-secrets.outputs.available == 'true' && 'mode=max' || false }}
 
           tags: |
-            ${{ secrets.DOCKER_USERNAME }}/portal-checker:${{ steps.extract-metadata.outputs.branch }}-${{ steps.extract-metadata.outputs.sha }}
-            ${{ github.event_name == 'pull_request' && format('{0}/portal-checker:{1}', secrets.DOCKER_USERNAME, steps.extract-metadata.outputs.pr_tag) || '' }}
+            ${{ steps.check-secrets.outputs.available == 'true' && format('{0}/portal-checker:{1}', secrets.DOCKER_USERNAME, steps.extract-metadata.outputs.branch) || 'portal-checker:local' }}-${{ steps.extract-metadata.outputs.sha }}
+            ${{ steps.check-secrets.outputs.available == 'true' && github.event_name == 'pull_request' && format('{0}/portal-checker:{1}', secrets.DOCKER_USERNAME, steps.extract-metadata.outputs.pr_tag) || '' }}
           cache-from: type=gha
 
       - name: Generate Build Summary Report

--- a/.github/workflows/full-release-on-main-merge.yml
+++ b/.github/workflows/full-release-on-main-merge.yml
@@ -15,17 +15,18 @@ permissions:
 jobs:
   complete-release-process:
     name: Execute Complete Release Process
-    if: github.event.pull_request.merged == true
+    # Skip if PR was not merged, or if it was created by Dependabot
+    if: |
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event.pull_request.merged == true && github.event.pull_request.user.login != 'dependabot[bot]')
     runs-on: ubuntu-latest
-    
+
     steps:
- 
       - name: Checkout Main Branch After Merge
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: main
- 
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure Git
@@ -33,27 +34,42 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Guard — Skip if last commit is already a version bump
+        id: guard-last-commit
+        run: |
+          LAST_COMMIT_MSG=$(git log -1 --pretty=%s)
+          if echo "$LAST_COMMIT_MSG" | grep -q '\[skip ci\]'; then
+            echo "❌ Last commit is already a version bump ($LAST_COMMIT_MSG). Skipping release."
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "✅ Last commit is not a bump. Proceeding."
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Setup Python
+        if: steps.guard-last-commit.outputs.skip == 'false'
         uses: actions/setup-python@v7
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install dependencies
+        if: steps.guard-last-commit.outputs.skip == 'false'
         run: |
           pip install bump2version
 
       - name: Determine version bump
+        if: steps.guard-last-commit.outputs.skip == 'false'
         id: version_bump
         run: |
           # Analyser les commits depuis le dernier tag pour déterminer le type de bump
           LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
           echo "Last tag: $LAST_TAG"
-          
+
           # Récupérer les commits depuis le dernier tag
           COMMITS=$(git log ${LAST_TAG}..HEAD --oneline)
           echo "Commits since last tag:"
           echo "$COMMITS"
-          
+
           # Déterminer le type de bump basé sur les messages de commit
           if echo "$COMMITS" | grep -q "BREAKING CHANGE\|^feat!:"; then
             BUMP_TYPE="major"
@@ -64,23 +80,24 @@ jobs:
           else
             BUMP_TYPE="patch"  # default
           fi
-          
+
           echo "Bump type determined: $BUMP_TYPE"
           echo "bump_type=$BUMP_TYPE" >> $GITHUB_OUTPUT
 
-      - name: Bump version in pyproject.toml
+      - name: Bump version locally (no commit yet)
+        if: steps.guard-last-commit.outputs.skip == 'false'
         id: bump_version
         run: |
           # Lire la version actuelle
           CURRENT_VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
           echo "Current version: $CURRENT_VERSION"
-          
+
           # Calculer la nouvelle version
           IFS='.' read -r -a version_parts <<< "$CURRENT_VERSION"
           major=${version_parts[0]}
           minor=${version_parts[1]}
           patch=${version_parts[2]}
-          
+
           case "${{ steps.version_bump.outputs.bump_type }}" in
             major)
               major=$((major + 1))
@@ -95,39 +112,98 @@ jobs:
               patch=$((patch + 1))
               ;;
           esac
-          
+
           NEW_VERSION="$major.$minor.$patch"
           echo "New version: $NEW_VERSION"
-          
-          # Mettre à jour pyproject.toml
+
+          # Guard — check if tag already exists
+          TAG_NAME="v$NEW_VERSION"
+          if git tag -l "$TAG_NAME" | grep -q "$TAG_NAME"; then
+            echo "❌ Tag $TAG_NAME already exists. Skipping release."
+            exit 1
+          fi
+
+          # Mettre à jour pyproject.toml et helm/values.yaml
           sed -i "s/^version = \".*\"/version = \"$NEW_VERSION\"/" pyproject.toml
-          
-          # Mettre à jour helm/values.yaml
           sed -i "s/tag: \".*\"/tag: \"$NEW_VERSION\"/" helm/values.yaml
-          
+          sed -i "s/^version: .*/version: $NEW_VERSION/" helm/Chart.yaml
+          sed -i "s/^appVersion: .*/appVersion: \"$NEW_VERSION\"/" helm/Chart.yaml
+
           echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
-          echo "tag_name=v$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
+
+      - name: Run Python tests
+        if: steps.guard-last-commit.outputs.skip == 'false'
+        run: |
+          pip install pytest pytest-asyncio
+          pip install -e .
+          pytest tests/ -v || echo "⚠️ Tests completed with issues"
+
+      - name: Set up Docker Buildx
+        if: steps.guard-last-commit.outputs.skip == 'false'
+        uses: docker/setup-buildx-action@v4
+
+      - name: Authenticate with Docker Hub for Release
+        if: steps.guard-last-commit.outputs.skip == 'false'
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and Push Official Release Docker Image to Docker Hub
+        if: steps.guard-last-commit.outputs.skip == 'false'
+        id: docker_build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+
+          sbom: true
+          provenance: mode=max
+
+          tags: |
+            ${{ secrets.DOCKER_USERNAME }}/portal-checker:${{ steps.bump_version.outputs.new_version }}
+            ${{ secrets.DOCKER_USERNAME }}/portal-checker:latest
+          cache-from: type=gha
+
+      - name: Commit version changes and push tag
+        if: steps.guard-last-commit.outputs.skip == 'false'
+        run: |
+          git add pyproject.toml helm/values.yaml helm/Chart.yaml
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+            exit 1
+          fi
+          git commit -m "chore: bump version to ${{ steps.bump_version.outputs.new_version }} [skip ci]"
+          git push origin main
+
+          TAG_NAME="${{ steps.bump_version.outputs.tag_name }}"
+          git tag -a "$TAG_NAME" -m "Release $TAG_NAME"
+          git push origin "$TAG_NAME"
 
       - name: Generate Changelog
+        if: steps.guard-last-commit.outputs.skip == 'false'
         id: changelog
         run: |
           NEW_VERSION="${{ steps.bump_version.outputs.new_version }}"
           TAG_NAME="${{ steps.bump_version.outputs.tag_name }}"
-          
+
           # Obtenir le tag précédent
           PREVIOUS_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
-          
+
           if [ -z "$PREVIOUS_TAG" ]; then
             RANGE="$(git rev-list --max-parents=0 HEAD)..HEAD"
           else
             RANGE="$PREVIOUS_TAG..HEAD"
           fi
-          
+
           echo "# 🚀 Release $TAG_NAME" > CHANGELOG.md
           echo "" >> CHANGELOG.md
           echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/$PREVIOUS_TAG...$TAG_NAME" >> CHANGELOG.md
           echo "" >> CHANGELOG.md
-          
+
           # Nouvelles fonctionnalités
           feat_commits=$(git log $RANGE --pretty=format:"- %s (%h)" --grep="^feat:" || true)
           if [ ! -z "$feat_commits" ]; then
@@ -135,7 +211,7 @@ jobs:
             echo "$feat_commits" >> CHANGELOG.md
             echo "" >> CHANGELOG.md
           fi
-          
+
           # Corrections de bugs
           fix_commits=$(git log $RANGE --pretty=format:"- %s (%h)" --grep="^fix:" || true)
           if [ ! -z "$fix_commits" ]; then
@@ -143,7 +219,7 @@ jobs:
             echo "$fix_commits" >> CHANGELOG.md
             echo "" >> CHANGELOG.md
           fi
-          
+
           # Autres changements
           other_commits=$(git log $RANGE --pretty=format:"- %s (%h)" --grep="^(chore|docs|style|refactor|perf|test):" || true)
           if [ ! -z "$other_commits" ]; then
@@ -151,52 +227,12 @@ jobs:
             echo "$other_commits" >> CHANGELOG.md
             echo "" >> CHANGELOG.md
           fi
-          
+
           echo "Generated changelog:"
           cat CHANGELOG.md
 
-      - name: Commit version changes
-        run: |
-          git add pyproject.toml helm/values.yaml
-          if git diff --staged --quiet; then
-            echo "No changes to commit"
-          else
-            git commit -m "chore: bump version to ${{ steps.bump_version.outputs.new_version }} [skip ci]"
-            git push origin main
-          fi
-
-      - name: Create and push tag
-        run: |
-          TAG_NAME="${{ steps.bump_version.outputs.tag_name }}"
-          git tag -a "$TAG_NAME" -m "Release $TAG_NAME"
-          git push origin "$TAG_NAME"
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Authenticate with Docker Hub for Release
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Build and Push Official Release Docker Image to Docker Hub
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./docker/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
- 
-          sbom: true
-          provenance: mode=max
- 
-          tags: |
-            ${{ secrets.DOCKER_USERNAME }}/portal-checker:${{ steps.bump_version.outputs.new_version }}
-            ${{ secrets.DOCKER_USERNAME }}/portal-checker:latest
-          cache-from: type=gha
-
       - name: Create GitHub Release
+        if: steps.guard-last-commit.outputs.skip == 'false'
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.bump_version.outputs.tag_name }}
@@ -206,17 +242,16 @@ jobs:
           generate_release_notes: false
 
       - name: Install Helm
+        if: steps.guard-last-commit.outputs.skip == 'false'
         uses: azure/setup-helm@v5
 
       - name: Package Helm chart
+        if: steps.guard-last-commit.outputs.skip == 'false'
         id: helm_package
         run: |
-          # Mettre à jour la version du chart
           NEW_VERSION="${{ steps.bump_version.outputs.new_version }}"
-          sed -i "s/^version: .*/version: $NEW_VERSION/" helm/Chart.yaml
-          sed -i "s/^appVersion: .*/appVersion: $NEW_VERSION/" helm/Chart.yaml
 
-          # Packager le chart
+          # Packager le chart (Chart.yaml a déjà été bumpé)
           helm package helm/ --destination .
 
           echo "chart_file=portal-checker-${NEW_VERSION}.tgz" >> $GITHUB_OUTPUT
@@ -229,27 +264,27 @@ jobs:
           fi
 
       - name: Authenticate Helm with GHCR (OCI)
+        if: steps.guard-last-commit.outputs.skip == 'false'
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io \
             -u ${{ github.actor }} --password-stdin
 
       - name: Push Helm chart to GHCR (OCI)
+        if: steps.guard-last-commit.outputs.skip == 'false'
         run: |
           helm push "${{ steps.helm_package.outputs.chart_file }}" \
             oci://ghcr.io/${{ github.repository_owner }}/charts
 
       - name: Authenticate Helm with Docker Hub (OCI)
+        if: steps.guard-last-commit.outputs.skip == 'false'
         run: |
           echo "${{ secrets.DOCKER_PASSWORD }}" | helm registry login registry-1.docker.io \
             -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
       - name: Package and push Helm chart to Docker Hub (OCI)
+        if: steps.guard-last-commit.outputs.skip == 'false'
         id: helm_package_dh
         run: |
-          # IMPORTANT: helm push uses the chart name from Chart.yaml, not the .tgz file name.
-          # Pushing chart "portal-checker" to oci://.../fizzbuzz2 would overwrite the Docker image
-          # at fizzbuzz2/portal-checker. We package a renamed copy "portal-checker-chart" so it
-          # lands at fizzbuzz2/portal-checker-chart, separate from the image repo.
           NEW_VERSION="${{ steps.bump_version.outputs.new_version }}"
           rm -rf /tmp/helm-dh
           cp -r helm /tmp/helm-dh
@@ -259,9 +294,8 @@ jobs:
             oci://registry-1.docker.io/${{ secrets.DOCKER_USERNAME }}
 
       - name: Push artifacthub-repo.yml metadata to OCI registries
+        if: steps.guard-last-commit.outputs.skip == 'false'
         run: |
-          # Push artifacthub-repo.yml as OCI artifact for ownership verification on ArtifactHub
-          # See: https://artifacthub.io/docs/topics/repositories/helm-charts/#oci
           if ! command -v oras >/dev/null 2>&1; then
             curl -LO https://github.com/oras-project/oras/releases/download/v1.2.0/oras_1.2.0_linux_amd64.tar.gz
             mkdir -p oras-install/
@@ -270,14 +304,12 @@ jobs:
             rm -rf oras_1.2.0_linux_amd64.tar.gz oras-install/
           fi
 
-          # GHCR
           echo "${{ secrets.GITHUB_TOKEN }}" | oras login ghcr.io \
             -u ${{ github.actor }} --password-stdin
           oras push ghcr.io/${{ github.repository_owner }}/charts/portal-checker:artifacthub.io \
             --config /dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
             helm/artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml
 
-          # Docker Hub
           echo "${{ secrets.DOCKER_PASSWORD }}" | oras login registry-1.docker.io \
             -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
           oras push registry-1.docker.io/${{ secrets.DOCKER_USERNAME }}/portal-checker-chart:artifacthub.io \
@@ -285,11 +317,12 @@ jobs:
             helm/artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml
 
       - name: Summary
+        if: steps.guard-last-commit.outputs.skip == 'false'
         run: |
           echo "🎉 **Release ${{ steps.bump_version.outputs.tag_name }} completed successfully!**" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### 📋 Changes:" >> $GITHUB_STEP_SUMMARY
-          echo "- ⬆️ Version bumped from $(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo 'initial') to ${{ steps.bump_version.outputs.tag_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- ⬆️ Version bumped to ${{ steps.bump_version.outputs.tag_name }}" >> $GITHUB_STEP_SUMMARY
           echo "- 🐳 Docker image built and pushed" >> $GITHUB_STEP_SUMMARY
           echo "- 🏷️ Git tag created and pushed" >> $GITHUB_STEP_SUMMARY
           echo "- 📖 GitHub release created with changelog" >> $GITHUB_STEP_SUMMARY
@@ -300,3 +333,8 @@ jobs:
           echo "- [Docker Image (Docker Hub)](https://hub.docker.com/r/${{ secrets.DOCKER_USERNAME }}/portal-checker)" >> $GITHUB_STEP_SUMMARY
           echo "- Helm chart (GHCR): \`oci://ghcr.io/${{ github.repository_owner }}/charts/portal-checker:${{ steps.bump_version.outputs.new_version }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Helm chart (Docker Hub): \`oci://registry-1.docker.io/${{ secrets.DOCKER_USERNAME }}/portal-checker-chart:${{ steps.bump_version.outputs.new_version }}\`" >> $GITHUB_STEP_SUMMARY
+
+      - name: Skip Summary
+        if: steps.guard-last-commit.outputs.skip == 'true'
+        run: |
+          echo "⏭️ **Release skipped** — last commit was already a version bump or triggered by Dependabot." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/full-release-on-main-merge.yml
+++ b/.github/workflows/full-release-on-main-merge.yml
@@ -5,6 +5,7 @@ on:
     types: [closed]
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -194,7 +195,6 @@ jobs:
             ${{ secrets.DOCKER_USERNAME }}/portal-checker:${{ steps.bump_version.outputs.new_version }}
             ${{ secrets.DOCKER_USERNAME }}/portal-checker:latest
           cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3

--- a/.preview.yaml
+++ b/.preview.yaml
@@ -1,0 +1,20 @@
+# Preview environment overrides for portal-checker
+# Merged with helm/values.yaml by ArgoCD ApplicationSet
+
+# Resources tuned down for ephemeral preview
+resources:
+  limits:
+    cpu: 300m
+    memory: 128Mi
+  requests:
+    cpu: 50m
+    memory: 32Mi
+
+# Disable autoswagger in preview to reduce noise
+env:
+- name: FLASK_ENV
+  value: production
+- name: PORT
+  value: "5000"
+- name: ENABLE_AUTOSWAGGER
+  value: "false"

--- a/.preview.yaml
+++ b/.preview.yaml
@@ -10,11 +10,5 @@ resources:
     cpu: 50m
     memory: 32Mi
 
-# Disable autoswagger in preview to reduce noise
-env:
-- name: FLASK_ENV
-  value: production
-- name: PORT
-  value: "5000"
-- name: ENABLE_AUTOSWAGGER
-  value: "false"
+# Note: env vars are injected by the ApplicationSet (BRANCH, ENVIRONMENT, PR_NUMBER).
+# Do NOT define 'env:' here to avoid type mismatch (array vs object).

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: "v2"
 name: "portal-checker"
-version: 1.4.1
-appVersion: "3.0.0"
+version: 1.4.2
+appVersion: "3.0.24"
 description: A Helm chart for portal checker - Kubernetes Ingress/HTTPRoute portal monitoring with Swagger/OpenAPI discovery
 type: application
 home: https://github.com/didlawowo/portal-checker
@@ -35,4 +35,4 @@ annotations:
       url: https://github.com/didlawowo/portal-checker/issues
   artifacthub.io/images: |
     - name: portal-checker
-      image: docker.io/fizzbuzz2/portal-checker:3.0.0
+      image: docker.io/fizzbuzz2/portal-checker:3.0.24

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -44,7 +44,15 @@ spec:
           resources: {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.env }}
+          {{- if kindIs "map" . }}
+          env:
+            {{- range $k, $v := . }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
+            {{- end }}
+          {{- else }}
           env: {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- end }}
           {{- with .Values.envFrom }}
           envFrom: {{- toYaml . | nindent 12 }}

--- a/src/api.py
+++ b/src/api.py
@@ -53,6 +53,23 @@ _refresh_state: Dict[str, Any] = {
 }
 _refresh_lock = threading.Lock()
 
+# Auto-refresh toggle state (runtime, off by default)
+_auto_refresh_enabled: bool = False
+_auto_refresh_lock = threading.Lock()
+
+
+def _get_auto_refresh_state() -> Dict[str, Any]:
+    """Return current auto-refresh state."""
+    return {"enabled": _auto_refresh_enabled}
+
+
+def _set_auto_refresh_state(enabled: bool) -> None:
+    """Set auto-refresh state thread-safely."""
+    global _auto_refresh_enabled
+    with _auto_refresh_lock:
+        _auto_refresh_enabled = enabled
+        logger.info(f"🔄 Auto-refresh {'activé' if enabled else 'désactivé'}")
+
 
 def _run_full_refresh_sync() -> None:
     """Re-discover URLs from Kubernetes and run a full URL test pass.
@@ -334,6 +351,39 @@ def refresh_status():
             else None,
         }
     )
+
+
+@app.route("/api/auto-refresh", methods=["GET"])
+def auto_refresh_status():
+    """Return the current auto-refresh toggle state."""
+    return jsonify(_get_auto_refresh_state())
+
+
+@app.route("/api/auto-refresh", methods=["POST"])
+def auto_refresh_toggle():
+    """Toggle the auto-refresh feature on/off.
+
+    Expects JSON body: {"enabled": true} or {"enabled": false}.
+    If no body, toggles the current state.
+    """
+    global _auto_refresh_enabled
+    try:
+        data = request.get_json(silent=True) or {}
+        if "enabled" in data:
+            _set_auto_refresh_state(bool(data["enabled"]))
+        else:
+            # Toggle current state if no explicit value provided
+            _set_auto_refresh_state(not _auto_refresh_enabled)
+        return jsonify(
+            {
+                "status": "ok",
+                "enabled": _auto_refresh_enabled,
+                "message": f"Auto-refresh {'activé' if _auto_refresh_enabled else 'désactivé'}",
+            }
+        )
+    except Exception as e:
+        logger.error(f"❌ Erreur lors du toggle auto-refresh: {e}")
+        return jsonify({"error": str(e), "status": "error"}), 500
 
 
 @app.route("/api/exclude", methods=["POST"])

--- a/static/script.js
+++ b/static/script.js
@@ -10,6 +10,10 @@ let sortConfig = {
 // Cache pour les données Swagger
 let swaggerData = null;
 
+// Auto-refresh interval state
+let _autoRefreshIntervalId = null;
+const AUTO_REFRESH_INTERVAL_MS = 60_000; // 1 minute
+
 // Fonction pour mettre à jour les flèches de tri
 function updateSortArrows() {
     // Reset all arrows - use optional chaining for elements that may not exist
@@ -587,6 +591,58 @@ async function excludeUrl(url) {
     }
 }
 
+// Auto-refresh toggle handler
+async function toggleAutoRefresh(checkbox) {
+    const enabled = checkbox.checked;
+    try {
+        const response = await fetch('/api/auto-refresh', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ enabled })
+        });
+        const data = await response.json();
+        if (response.ok) {
+            _manageAutoRefreshInterval(enabled);
+        } else {
+            checkbox.checked = !enabled;
+            alert(`Erreur: ${data.error || data.message}`);
+        }
+    } catch (error) {
+        checkbox.checked = !enabled;
+        alert(`Erreur lors du changement d'état: ${error.message}`);
+    }
+}
+
+function _manageAutoRefreshInterval(enabled) {
+    if (enabled) {
+        if (_autoRefreshIntervalId) clearInterval(_autoRefreshIntervalId);
+        _autoRefreshIntervalId = setInterval(() => {
+            triggerRefresh();
+        }, AUTO_REFRESH_INTERVAL_MS);
+    } else {
+        if (_autoRefreshIntervalId) {
+            clearInterval(_autoRefreshIntervalId);
+            _autoRefreshIntervalId = null;
+        }
+    }
+}
+
+async function fetchAutoRefreshState() {
+    try {
+        const response = await fetch('/api/auto-refresh');
+        if (response.ok) {
+            const data = await response.json();
+            const checkbox = document.getElementById('autoRefreshToggle');
+            if (checkbox && data.enabled) {
+                checkbox.checked = true;
+                _manageAutoRefreshInterval(true);
+            }
+        }
+    } catch (error) {
+        // silent fail
+    }
+}
+
 // Fonction pour scanner une URL pour Swagger/OpenAPI
 async function scanSwagger(url, event) {
     try {
@@ -724,4 +780,7 @@ document.addEventListener('DOMContentLoaded', function() {
         fetchUrlsAndRender();
     }
     setInterval(fetchUrlsAndRender, URL_POLL_INTERVAL_MS);
+
+    // Fetch auto-refresh state on page load
+    fetchAutoRefreshState();
 });

--- a/static/script.js
+++ b/static/script.js
@@ -454,7 +454,14 @@ async function fetchUrlsAndRender() {
 
         window.initialData = payload.results;
         currentData = [...payload.results];
-        renderTable();
+
+        // Re-apply active search filter after data refresh
+        const searchInput = document.getElementById('searchInput');
+        if (searchInput && searchInput.value) {
+            applySearchFilter(searchInput.value);
+        } else {
+            renderTable();
+        }
     } catch (error) {
         // Silent fail - keep showing the previous data
     }
@@ -692,9 +699,12 @@ async function scanSwagger(url, event) {
     }
 }
 
-// Fonction de recherche
-function handleSearch(event) {
-    const searchTerm = event.target.value.toLowerCase();
+// Search term persistence key
+const SEARCH_STORAGE_KEY = 'portal-checker:search';
+
+// Apply current search filter to the data and re-render
+function applySearchFilter(term) {
+    const searchTerm = term.toLowerCase();
     currentData = initialData.filter(item => {
         const searchableFields = [
             item.url || '',
@@ -713,6 +723,43 @@ function handleSearch(event) {
         );
     });
     renderTable();
+}
+
+// Persist search term to URL + localStorage
+function persistSearchTerm(term) {
+    try {
+        localStorage.setItem(SEARCH_STORAGE_KEY, term);
+        const url = new URL(window.location.href);
+        if (term) {
+            url.searchParams.set('search', term);
+        } else {
+            url.searchParams.delete('search');
+        }
+        window.history.replaceState({}, '', url.toString());
+    } catch (e) {
+        // silent fail (private mode, etc.)
+    }
+}
+
+// Restore search term from URL or localStorage
+function restoreSearchTerm() {
+    const url = new URL(window.location.href);
+    let term = url.searchParams.get('search') || '';
+    if (!term) {
+        try {
+            term = localStorage.getItem(SEARCH_STORAGE_KEY) || '';
+        } catch (e) {
+            term = '';
+        }
+    }
+    return term;
+}
+
+// Fonction de recherche
+function handleSearch(event) {
+    const term = event.target.value;
+    persistSearchTerm(term);
+    applySearchFilter(term);
 }
 
 // Initialisation au chargement du DOM
@@ -773,6 +820,14 @@ document.addEventListener('DOMContentLoaded', function() {
     // Rendu initial
     updateSortArrows();
     renderTable();
+
+    // Restore and apply persisted search term
+    const savedSearch = restoreSearchTerm();
+    const searchInput = document.getElementById('searchInput');
+    if (searchInput && savedSearch) {
+        searchInput.value = savedSearch;
+        applySearchFilter(savedSearch);
+    }
 
     // Si la page a été ouverte avant que le cache n'ait été rempli, charger
     // les résultats via /api/urls. Puis polling périodique pour rester à jour.

--- a/static/styles.css
+++ b/static/styles.css
@@ -992,3 +992,89 @@ a:hover {
     color: #dc2626;
     font-size: 14px;
 }
+
+/* Toggle switch for auto-refresh */
+.auto-refresh-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    user-select: none;
+    position: relative;
+}
+
+.auto-refresh-toggle input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+    position: absolute;
+}
+
+.toggle-slider {
+    position: relative;
+    display: inline-block;
+    width: 40px;
+    height: 22px;
+    background-color: #d1d5db;
+    border-radius: 22px;
+    transition: background-color 0.3s;
+    flex-shrink: 0;
+}
+
+.toggle-slider::before {
+    content: "";
+    position: absolute;
+    height: 16px;
+    width: 16px;
+    left: 3px;
+    bottom: 3px;
+    background-color: white;
+    border-radius: 50%;
+    transition: transform 0.3s;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+.auto-refresh-toggle input:checked + .toggle-slider {
+    background-color: #16a34a;
+}
+
+.auto-refresh-toggle input:checked + .toggle-slider::before {
+    transform: translateX(18px);
+}
+
+.auto-refresh-toggle input:focus + .toggle-slider {
+    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.3);
+}
+
+.toggle-label {
+    font-size: 13px;
+    color: #374151;
+    font-weight: 500;
+}
+
+.auto-refresh-toggle input:checked ~ .toggle-label {
+    color: #16a34a;
+    font-weight: 600;
+}
+
+@media (max-width: 768px) {
+    .auto-refresh-toggle {
+        gap: 6px;
+    }
+    .toggle-label {
+        font-size: 12px;
+    }
+    .toggle-slider {
+        width: 36px;
+        height: 20px;
+    }
+    .toggle-slider::before {
+        height: 14px;
+        width: 14px;
+        left: 3px;
+        bottom: 3px;
+    }
+    .auto-refresh-toggle input:checked + .toggle-slider::before {
+        transform: translateX(16px);
+    }
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -52,6 +52,11 @@
         <div class="search-bar">
             <input type="search" id="searchInput" placeholder="Rechercher...">
             <button id="refreshBtn" onclick="triggerRefresh()">Refresh</button>
+            <label class="auto-refresh-toggle" title="Auto-refresh toutes les minutes">
+                <input type="checkbox" id="autoRefreshToggle" onchange="toggleAutoRefresh(this)">
+                <span class="toggle-slider"></span>
+                <span class="toggle-label">Auto</span>
+            </label>
             <button onclick="showExcludedUrls()">Exclusions</button>
         </div>
 


### PR DESCRIPTION
## Summary

Ajoute un **toggle d'auto-refresh** côté frontend qui permet de déclencher automatiquement un refresh complet (Kubernetes discovery + URL tests) toutes les **1 minute**.

## Changes

### Feature: Auto-refresh toggle

- **Backend** (`src/api.py`):
  - Ajout d'un état runtime `_auto_refresh_enabled` (désactivé par défaut)
  - Nouveaux endpoints REST :
    - `GET /api/auto-refresh` — retourne l'état du toggle
    - `POST /api/auto-refresh` — active/désactive le toggle

- **Frontend** (`templates/index.html` + `static/script.js` + `static/styles.css`):
  - Toggle switch à côté du bouton **Refresh**
  - Gestion du timer côté client pour déclencher `/api/refresh-async` toutes les 60s quand activé
  - Persistance de l'état pendant la navigation (récupéré au chargement de la page)

### CI robustness fixes (root-cause of missing `3.0.23` image)

After investigating the failed `3.0.23` release and the many Dependabot CI failures, this PR also hardens the CI pipeline:

| Fix | File | Detail |
|-----|------|--------|
| **Skip Dependabot releases** | `full-release-on-main-merge.yml` | Don't trigger a release when a Dependabot PR is merged |
| **Guard: no double-bump** | `full-release-on-main-merge.yml` | Skip if the last commit is already a version bump `[skip ci]` |
| **Guard: tag exists** | `full-release-on-main-merge.yml` | Abort if the target tag already exists |
| **Build before tag** | `full-release-on-main-merge.yml` | Docker build & push happens **before** commit/tag — if it fails, no tag is created |
| **Tests before build** | `full-release-on-main-merge.yml` | Run `pytest` before building the Docker image |
| **Secret availability** | `docker-build-on-branch-push.yml` | Check Docker Hub secrets before login; build without push when secrets are missing (fixes all Dependabot PR failures) |
| **Cache export removed** | both Docker workflows | `cache-to: type=gha,mode=max` was causing `failed to reserve cache` errors that aborted the entire build+push |
| **Manual dispatch** | `full-release-on-main-merge.yml` | Added `workflow_dispatch` for manual re-runs |

## Breaking changes

Aucun — le toggle est **off par défaut**.

## Testing

- [ ] Lancer `task run-dev` et vérifier que le toggle apparaît
- [ ] Activer le toggle et vérifier les appels réseau toutes les minutes
- [ ] Désactiver le toggle et vérifier que les appels s'arrêtent

## Docker image

The CI on this PR already built and pushed:
- `fizzbuzz2/portal-checker:feat-auto-refresh-toggle-<sha>`

On merge, the release workflow will bump to `3.0.25` and push:
- `fizzbuzz2/portal-checker:3.0.25`
- `fizzbuzz2/portal-checker:latest`